### PR TITLE
feat(Segment): improve fields descriptions in segment

### DIFF
--- a/packages/destination-actions/src/destinations/talon-one/trackEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/talon-one/trackEvent/generated-types.ts
@@ -2,11 +2,11 @@
 
 export interface Payload {
   /**
-   * Unique identifier of the customer profile associated to the event.
+   * The customer profile integration ID to use in Talon.One. It is the identifier of the customer profile associated to the event.
    */
   customerProfileId: string
   /**
-   * It is just the name of your event.
+   * The name of the event sent to Talon.One.
    */
   eventType: string
   /**
@@ -14,7 +14,7 @@ export interface Payload {
    */
   type: string
   /**
-   * Arbitrary additional JSON data associated with the event.
+   * Extra attributes associated with the event. See more info https://docs.talon.one/docs/product/account/dev-tools/managing-attributes
    */
   attributes?: {
     [k: string]: unknown

--- a/packages/destination-actions/src/destinations/talon-one/trackEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/talon-one/trackEvent/generated-types.ts
@@ -14,7 +14,7 @@ export interface Payload {
    */
   type: string
   /**
-   * Extra attributes associated with the event. See more info https://docs.talon.one/docs/product/account/dev-tools/managing-attributes
+   * Extra attributes associated with the event. [See more details](https://docs.talon.one/docs/product/account/dev-tools/managing-attributes)
    */
   attributes?: {
     [k: string]: unknown

--- a/packages/destination-actions/src/destinations/talon-one/trackEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/talon-one/trackEvent/generated-types.ts
@@ -14,7 +14,7 @@ export interface Payload {
    */
   type: string
   /**
-   * Extra attributes associated with the event. [See more details](https://docs.talon.one/docs/product/account/dev-tools/managing-attributes)
+   * Extra attributes associated with the event. [See more details](https://docs.talon.one/docs/product/account/dev-tools/managing-attributes).
    */
   attributes?: {
     [k: string]: unknown

--- a/packages/destination-actions/src/destinations/talon-one/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/talon-one/trackEvent/index.ts
@@ -28,7 +28,7 @@ const action: ActionDefinition<Settings, Payload> = {
     attributes: {
       label: 'Attribute-Value pairs',
       description:
-        'Extra attributes associated with the event. See more info https://docs.talon.one/docs/product/account/dev-tools/managing-attributes',
+        'Extra attributes associated with the event. [See more details](https://docs.talon.one/docs/product/account/dev-tools/managing-attributes)',
       type: 'object',
       required: false
     }

--- a/packages/destination-actions/src/destinations/talon-one/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/talon-one/trackEvent/index.ts
@@ -28,7 +28,7 @@ const action: ActionDefinition<Settings, Payload> = {
     attributes: {
       label: 'Attribute-Value pairs',
       description:
-        'Extra attributes associated with the event. [See more details](https://docs.talon.one/docs/product/account/dev-tools/managing-attributes)',
+        'Extra attributes associated with the event. [See more details](https://docs.talon.one/docs/product/account/dev-tools/managing-attributes).',
       type: 'object',
       required: false
     }

--- a/packages/destination-actions/src/destinations/talon-one/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/talon-one/trackEvent/index.ts
@@ -8,13 +8,14 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     customerProfileId: {
       label: 'Customer Profile ID',
-      description: 'Unique identifier of the customer profile associated to the event.',
+      description:
+        'The customer profile integration ID to use in Talon.One. It is the identifier of the customer profile associated to the event.',
       type: 'string',
       required: true
     },
     eventType: {
       label: 'Event Type',
-      description: 'It is just the name of your event.',
+      description: 'The name of the event sent to Talon.One.',
       type: 'string',
       required: true
     },
@@ -26,7 +27,8 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     attributes: {
       label: 'Attribute-Value pairs',
-      description: 'Arbitrary additional JSON data associated with the event.',
+      description:
+        'Extra attributes associated with the event. See more info https://docs.talon.one/docs/product/account/dev-tools/managing-attributes',
       type: 'object',
       required: false
     }

--- a/packages/destination-actions/src/destinations/talon-one/updateAudience/index.ts
+++ b/packages/destination-actions/src/destinations/talon-one/updateAudience/index.ts
@@ -3,8 +3,8 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
 const action: ActionDefinition<Settings, Payload> = {
-  title: 'Update Audience',
-  description: 'This synchronizes audience data if there is an existing audience entity.',
+  title: 'Update Audience Name',
+  description: 'This updates the audience name if there is an existing audience entity.',
   fields: {
     audienceId: {
       label: 'Segment Audience ID',


### PR DESCRIPTION
### Problem
@arthurf suggestion to improve UX in Segment

### Solution
1. `Unique identifier of the customer profile associated to the event.` -> `The customer profile integration ID to use in Talon.One. It is the identifier of the customer profile associated to the event.`
2. `It is just the name of your event.` -> `The name of the event sent to Talon.One.`
3. `Arbitrary additional JSON data associated with the event.` -> `Extra attributes associated with the event. See more info: https://docs.talon.one/docs/product/account/dev-tools/managing-attributes`