### PR TITLE
fix(segment) fixed the mapper and tests to work with update customer profile attributes endpoint

### DIFF
--- a/packages/destination-actions/src/destinations/talon-one/updateCustomerProfilesAttributes/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/talon-one/updateCustomerProfilesAttributes/__tests__/index.test.ts
@@ -14,7 +14,7 @@ describe('Talon.One - Update Attribute-Value pairs in customer profiles', () => 
         }
       })
     } catch (err) {
-      expect(err.message).toContain("The root value is missing the required field 'customerProfileId'.")
+      expect(err.message).toContain("The root value is missing the required field 'data'.")
     }
   })
 
@@ -26,12 +26,14 @@ describe('Talon.One - Update Attribute-Value pairs in customer profiles', () => 
           deployment: 'https://something.europe-west1.talon.one'
         },
         mapping: {
-          data: [],
-          mutualAttributes: [{ attributeName1: 'value' }, { attributeName2: 'value' }]
+          mutualAttributes: {
+            attributeName1: 'value',
+            attributeName2: 'value'
+          }
         }
       })
     } catch (err) {
-      expect(err.message).toContain("The root value is missing the required field 'customerProfileId'.")
+      expect(err.message).toContain("The root value is missing the required field 'data'.")
     }
   })
 
@@ -61,11 +63,15 @@ describe('Talon.One - Update Attribute-Value pairs in customer profiles', () => 
         deployment: 'https://something.europe-west1.talon.one'
       },
       mapping: {
-        customerProfileId: 'abc123',
-        attributes: {
-          attributeName1: 'value',
-          attributeName2: 'value'
-        },
+        data: [
+          {
+            customerProfileId: 'abc123',
+            attributes: {
+              attributeName1: 'value',
+              attributeName2: 'value'
+            }
+          }
+        ],
         mutualAttributes: {
           attributeName3: 'value'
         }

--- a/packages/destination-actions/src/destinations/talon-one/updateCustomerProfilesAttributes/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/talon-one/updateCustomerProfilesAttributes/__tests__/index.test.ts
@@ -37,12 +37,46 @@ describe('Talon.One - Update Attribute-Value pairs in customer profiles', () => 
     }
   })
 
+  it('customer profile ID is missed', async () => {
+    try {
+      await testDestination.testAction('updateCustomerProfilesAttributes', {
+        settings: {
+          apiKey: 'some_api_key',
+          deployment: 'https://something.europe-west1.talon.one'
+        },
+        mapping: {
+          data: [
+            {
+              attributes: {
+                attributeName1: 'value',
+                attributeName2: 'value'
+              }
+            }
+          ],
+          mutualAttributes: {
+            attributeName1: 'value',
+            attributeName2: 'value'
+          }
+        }
+      })
+    } catch (err) {
+      expect(err.message).toContain("The value at /data/0 is missing the required field 'customerProfileId'.")
+    }
+  })
+
   it('should work', async () => {
     nock('https://integration.talon.one')
       .put('/segment/customer_profiles/attributes', {
         data: [
           {
             customerProfileId: 'abc123',
+            attributes: {
+              attributeName1: 'value',
+              attributeName2: 'value'
+            }
+          },
+          {
+            customerProfileId: 'abc456',
             attributes: {
               attributeName1: 'value',
               attributeName2: 'value'
@@ -66,6 +100,13 @@ describe('Talon.One - Update Attribute-Value pairs in customer profiles', () => 
         data: [
           {
             customerProfileId: 'abc123',
+            attributes: {
+              attributeName1: 'value',
+              attributeName2: 'value'
+            }
+          },
+          {
+            customerProfileId: 'abc456',
             attributes: {
               attributeName1: 'value',
               attributeName2: 'value'

--- a/packages/destination-actions/src/destinations/talon-one/updateCustomerProfilesAttributes/generated-types.ts
+++ b/packages/destination-actions/src/destinations/talon-one/updateCustomerProfilesAttributes/generated-types.ts
@@ -2,17 +2,22 @@
 
 export interface Payload {
   /**
-   * The customer profile integration identifier to use in Talon.One.
+   * An array of JSON objects that contains customer profile identifier and list of attributes and their values. Customer profile ID is required.
    */
-  customerProfileId: string
+  data: {
+    /**
+     * The customer profile integration identifier to use in Talon.One.
+     */
+    customerProfileId: string
+    /**
+     * Extra attributes associated with the customer profile. [See more info](https://docs.talon.one/docs/product/account/dev-tools/managing-attributes).
+     */
+    attributes?: {
+      [k: string]: unknown
+    }
+  }[]
   /**
-   * Extra attributes associated with the customer profile. [See more info](https://docs.talon.one/docs/product/account/dev-tools/managing-attributes).
-   */
-  attributes?: {
-    [k: string]: unknown
-  }
-  /**
-   * Extra attributes associated with the customer profile. [See more info](https://docs.talon.one/docs/product/account/dev-tools/managing-attributes).
+   * This may contain mutual list of attributes and their values for every customer profile in the "data" array.
    */
   mutualAttributes?: {
     [k: string]: unknown

--- a/packages/destination-actions/src/destinations/talon-one/updateCustomerProfilesAttributes/index.ts
+++ b/packages/destination-actions/src/destinations/talon-one/updateCustomerProfilesAttributes/index.ts
@@ -7,21 +7,31 @@ const action: ActionDefinition<Settings, Payload> = {
   title: 'Update Multiple Customer Profiles’ Attributes',
   description: 'This updates attributes for multiple customer profiles.',
   fields: {
-    customerProfileId: { ...customerProfileId },
-    attributes: { ...attribute },
-    mutualAttributes: { ...attribute }
+    data: {
+      label: 'Data item to change customer profile attributes',
+      description:
+        'An array of JSON objects that contains customer profile identifier and list of attributes and their values. Customer profile ID is required.',
+      type: 'object',
+      multiple: true,
+      properties: {
+        customerProfileId: { ...customerProfileId },
+        attributes: { ...attribute }
+      },
+      required: true
+    },
+    mutualAttributes: {
+      ...attribute,
+      label: 'Mutual Attribute-Value pairs',
+      description:
+        'This may contain mutual list of attributes and their values for every customer profile in the "data" array.'
+    }
   },
   perform: (request, { payload }) => {
     // Make your partner api request here!
     return request(`https://integration.talon.one/segment/customer_profiles/attributes`, {
       method: 'put',
       json: {
-        data: [
-          {
-            customerProfileId: payload.customerProfileId,
-            attributes: payload.attributes
-          }
-        ],
+        data: payload.data,
         mutualAttributes: payload.mutualAttributes
       }
     })


### PR DESCRIPTION
## problem

the mapper in the segment UI has no option to add several data items.

## solution

`customer profile attributes` endpoint has to have similar to `customer profile audiences` endpoint approach that uses `data` array with properties.