### PR TITLE
Sc 9770 add `update customer profile v2` and `update customer session` endpoints

### DIFF
--- a/packages/destination-actions/src/destinations/talon-one/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/talon-one/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -88,6 +88,41 @@ Object {
 }
 `;
 
+exports[`Testing snapshot for actions-talon-one destination: updateCustomerProfileV2 action - all fields 1`] = `
+Object {
+  "attributes": Object {
+    "testType": "8Yg2!m9eP3^U",
+  },
+  "attributesInfo": Array [
+    Object {
+      "name": "8Yg2!m9eP3^U",
+      "type": "8Yg2!m9eP3^U",
+    },
+  ],
+  "audiencesChanges": Object {
+    "adds": Array [
+      Object {
+        "integrationId": "8Yg2!m9eP3^U",
+        "name": "8Yg2!m9eP3^U",
+      },
+    ],
+    "deletes": Array [
+      Object {
+        "integrationId": "8Yg2!m9eP3^U",
+        "name": "8Yg2!m9eP3^U",
+      },
+    ],
+  },
+  "runRuleEngine": true,
+}
+`;
+
+exports[`Testing snapshot for actions-talon-one destination: updateCustomerProfileV2 action - required fields 1`] = `
+Object {
+  "audiencesChanges": Object {},
+}
+`;
+
 exports[`Testing snapshot for actions-talon-one destination: updateCustomerProfilesAttributes action - all fields 1`] = `
 Object {
   "data": Array [
@@ -137,5 +172,11 @@ Object {
       "customerProfileId": "g64#i$3",
     },
   ],
+}
+`;
+
+exports[`Testing snapshot for actions-talon-one destination: updateCustomerSession action - required fields 1`] = `
+Object {
+  "customerSession": Object {},
 }
 `;

--- a/packages/destination-actions/src/destinations/talon-one/index.ts
+++ b/packages/destination-actions/src/destinations/talon-one/index.ts
@@ -8,6 +8,7 @@ import updateCustomerProfile from './updateCustomerProfile'
 import updateCustomerProfilesAttributes from './updateCustomerProfilesAttributes'
 import updateCustomerProfilesAudiences from './updateCustomerProfilesAudiences'
 import trackEvent from './trackEvent'
+import updateCustomerProfileV2 from './updateCustomerProfileV2'
 
 const destination: DestinationDefinition<Settings> = {
   name: 'Talon.One (Actions)',
@@ -54,7 +55,8 @@ const destination: DestinationDefinition<Settings> = {
     updateCustomerProfile,
     updateCustomerProfilesAttributes,
     updateCustomerProfilesAudiences,
-    trackEvent
+    trackEvent,
+    updateCustomerProfileV2
   }
 }
 

--- a/packages/destination-actions/src/destinations/talon-one/index.ts
+++ b/packages/destination-actions/src/destinations/talon-one/index.ts
@@ -9,6 +9,7 @@ import updateCustomerProfilesAttributes from './updateCustomerProfilesAttributes
 import updateCustomerProfilesAudiences from './updateCustomerProfilesAudiences'
 import trackEvent from './trackEvent'
 import updateCustomerProfileV2 from './updateCustomerProfileV2'
+import updateCustomerSession from './updateCustomerSession'
 
 const destination: DestinationDefinition<Settings> = {
   name: 'Talon.One (Actions)',
@@ -56,7 +57,8 @@ const destination: DestinationDefinition<Settings> = {
     updateCustomerProfilesAttributes,
     updateCustomerProfilesAudiences,
     trackEvent,
-    updateCustomerProfileV2
+    updateCustomerProfileV2,
+    updateCustomerSession
   }
 }
 

--- a/packages/destination-actions/src/destinations/talon-one/t1-properties.ts
+++ b/packages/destination-actions/src/destinations/talon-one/t1-properties.ts
@@ -38,3 +38,35 @@ export const deleteAudienceId: InputField = {
   ...audienceId,
   label: 'List of audience ID to dissociate with the customer profile.'
 }
+
+export const audience: InputField = {
+  label: 'Audience (the label must not be used)',
+  description: 'Audience name and integrationId',
+  type: 'object',
+  properties: {
+    name: {
+      label: 'Name',
+      description: 'The name of the audience.',
+      type: 'string',
+      required: true
+    },
+    integrationId: {
+      label: 'integrationId',
+      description: 'The integrationId of the audience.',
+      type: 'string',
+      required: false
+    }
+  },
+  multiple: true,
+  required: false
+}
+
+export const audiencesToAdd: InputField = {
+  ...audience,
+  label: 'The audiences for the customer to join.'
+}
+
+export const audiencesToDelete: InputField = {
+  ...audience,
+  label: 'The audiences for the customer to leave.'
+}

--- a/packages/destination-actions/src/destinations/talon-one/t1-properties.ts
+++ b/packages/destination-actions/src/destinations/talon-one/t1-properties.ts
@@ -96,3 +96,38 @@ export const audiencesToDelete: InputField = {
     ]
   }
 }
+
+export const attributesInfo: InputField = {
+  label: 'Attributes info',
+  description: 'Use this field if you want to identify an attribute with a specific type',
+  type: 'object',
+  required: false,
+  multiple: true,
+  properties: {
+    name: {
+      label: 'Name',
+      description: 'Attribute name',
+      type: 'string',
+      required: true
+    },
+    type: {
+      label: 'Type',
+      description: 'Attribute type. Can be only `string`, `time`, `number`, `boolean`, `location`',
+      type: 'string',
+      required: true
+    }
+  },
+  default: {
+    '@arrayPath': [
+      '$.properties.attributesInfo',
+      {
+        name: {
+          '@path': '$.name'
+        },
+        type: {
+          '@path': '$.type'
+        }
+      }
+    ]
+  }
+}

--- a/packages/destination-actions/src/destinations/talon-one/t1-properties.ts
+++ b/packages/destination-actions/src/destinations/talon-one/t1-properties.ts
@@ -41,18 +41,18 @@ export const deleteAudienceId: InputField = {
 
 export const audience: InputField = {
   label: 'Audience (the label must not be used)',
-  description: 'Audience name and integrationId',
+  description: 'Audience name and integration ID',
   type: 'object',
   properties: {
     name: {
       label: 'Name',
-      description: 'The name of the audience.',
+      description: 'The audience name.',
       type: 'string',
       required: true
     },
     integrationId: {
-      label: 'integrationId',
-      description: 'The integrationId of the audience.',
+      label: 'integrationID',
+      description: 'The audience integration ID.',
       type: 'string',
       required: false
     }

--- a/packages/destination-actions/src/destinations/talon-one/t1-properties.ts
+++ b/packages/destination-actions/src/destinations/talon-one/t1-properties.ts
@@ -63,10 +63,36 @@ export const audience: InputField = {
 
 export const audiencesToAdd: InputField = {
   ...audience,
-  label: 'The audiences for the customer to join.'
+  label: 'The audiences for the customer to join.',
+  default: {
+    '@arrayPath': [
+      '$.properties.audiencesToAdd',
+      {
+        name: {
+          '@path': '$.name'
+        },
+        integrationId: {
+          '@path': '$.integrationId'
+        }
+      }
+    ]
+  }
 }
 
 export const audiencesToDelete: InputField = {
   ...audience,
-  label: 'The audiences for the customer to leave.'
+  label: 'The audiences for the customer to leave.',
+  default: {
+    '@arrayPath': [
+      '$.properties.audiencesToDelete',
+      {
+        name: {
+          '@path': '$.name'
+        },
+        integrationId: {
+          '@path': '$.integrationId'
+        }
+      }
+    ]
+  }
 }

--- a/packages/destination-actions/src/destinations/talon-one/updateCustomerProfileV2/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/talon-one/updateCustomerProfileV2/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for TalonOne's updateCustomerProfileV2 destination action: all fields 1`] = `
+Object {
+  "attributes": Object {
+    "testType": "wJ*BaaPwe",
+  },
+  "attributesInfo": Array [
+    Object {
+      "name": "wJ*BaaPwe",
+      "type": "wJ*BaaPwe",
+    },
+  ],
+  "audiencesChanges": Object {
+    "adds": Array [
+      Object {
+        "integrationId": "wJ*BaaPwe",
+        "name": "wJ*BaaPwe",
+      },
+    ],
+    "deletes": Array [
+      Object {
+        "integrationId": "wJ*BaaPwe",
+        "name": "wJ*BaaPwe",
+      },
+    ],
+  },
+  "runRuleEngine": true,
+}
+`;
+
+exports[`Testing snapshot for TalonOne's updateCustomerProfileV2 destination action: required fields 1`] = `
+Object {
+  "audiencesChanges": Object {},
+}
+`;

--- a/packages/destination-actions/src/destinations/talon-one/updateCustomerProfileV2/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/talon-one/updateCustomerProfileV2/__tests__/index.test.ts
@@ -1,0 +1,132 @@
+import { createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(Destination)
+
+describe('TalonOne.updateCustomerProfileV2', () => {
+  it('misses request body', async () => {
+    try {
+      await testDestination.testAction('updateCustomerProfileV2', {
+        settings: {
+          apiKey: 'some_api_key',
+          deployment: 'https://internal.europe-west1.talon.one'
+        }
+      })
+    } catch (err) {
+      expect(err.message).toContain("The root value is missing the required field 'customerProfileId'.")
+    }
+  })
+
+  it('misses customer profile ID', async () => {
+    try {
+      await testDestination.testAction('updateCustomerProfileV2', {
+        settings: {
+          apiKey: 'some_api_key',
+          deployment: 'https://something.europe-west1.talon.one'
+        },
+        mapping: {
+          customerProfileId: '',
+          audiencesToAdd: [],
+          audiencesToDelete: [],
+          runRuleEngine: true,
+          attributes: [],
+          attributesInfo: []
+        }
+      })
+    } catch (err) {
+      expect(err.message).toContain("The root value is missing the required field 'customerProfileId'.")
+    }
+  })
+
+  it('should work', async () => {
+    nock('https://integration.talon.one')
+      .put(`/segment/customer_profile_v2/abc123`, {
+        audiencesChanges: {
+          adds: [
+            {
+              name: 'testAudience1',
+              integrationId: 'testAudience1IntegrationId'
+            },
+            {
+              name: 'testAudience2',
+              integrationId: 'testAudience2IntegrationId'
+            }
+          ],
+          deletes: [
+            {
+              name: 'testAudience3',
+              integrationId: 'testAudience3IntegrationId'
+            },
+            {
+              name: 'testAudience4',
+              integrationId: 'testAudience4IntegrationId'
+            }
+          ]
+        },
+        runRuleEngine: true,
+        attributes: {
+          testAttribute1: 'testValue1',
+          testAttribute2: 'testValue2'
+        },
+        attributesInfo: [
+          {
+            name: 'testAttribute1',
+            type: 'string'
+          },
+          {
+            name: 'testAttribute2',
+            type: 'string'
+          }
+        ]
+      })
+      .matchHeader('Authorization', 'ApiKey-v1 some_api_key')
+      .matchHeader('destination-hostname', 'https://something.europe-west1.talon.one')
+      .reply(200)
+
+    await testDestination.testAction('updateCustomerProfileV2', {
+      settings: {
+        apiKey: 'some_api_key',
+        deployment: 'https://something.europe-west1.talon.one'
+      },
+      mapping: {
+        customerProfileId: 'abc123',
+        audiencesToAdd: [
+          {
+            name: 'testAudience1',
+            integrationId: 'testAudience1IntegrationId'
+          },
+          {
+            name: 'testAudience2',
+            integrationId: 'testAudience2IntegrationId'
+          }
+        ],
+        audiencesToDelete: [
+          {
+            name: 'testAudience3',
+            integrationId: 'testAudience3IntegrationId'
+          },
+          {
+            name: 'testAudience4',
+            integrationId: 'testAudience4IntegrationId'
+          }
+        ],
+        runRuleEngine: true,
+        attributes: {
+          testAttribute1: 'testValue1',
+          testAttribute2: 'testValue2'
+        },
+        attributesInfo: [
+          {
+            name: 'testAttribute1',
+            type: 'string'
+          },
+          {
+            name: 'testAttribute2',
+            type: 'string'
+          }
+        ]
+      }
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/talon-one/updateCustomerProfileV2/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/talon-one/updateCustomerProfileV2/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'updateCustomerProfileV2'
+const destinationSlug = 'TalonOne'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/talon-one/updateCustomerProfileV2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/talon-one/updateCustomerProfileV2/generated-types.ts
@@ -1,0 +1,57 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The customer profile integration identifier to use in Talon.One.
+   */
+  customerProfileId: string
+  /**
+   * Audience name and integrationId
+   */
+  audiencesToAdd?: {
+    /**
+     * The name of the audience.
+     */
+    name: string
+    /**
+     * The integrationId of the audience.
+     */
+    integrationId?: string
+  }[]
+  /**
+   * Audience name and integrationId
+   */
+  audiencesToDelete?: {
+    /**
+     * The name of the audience.
+     */
+    name: string
+    /**
+     * The integrationId of the audience.
+     */
+    integrationId?: string
+  }[]
+  /**
+   * This runs rule engine in Talon.One upon updating customer profile. Set to true to trigger rules.
+   */
+  runRuleEngine?: boolean
+  /**
+   * Extra attributes associated with the customer profile. [See more info](https://docs.talon.one/docs/product/account/dev-tools/managing-attributes).
+   */
+  attributes?: {
+    [k: string]: unknown
+  }
+  /**
+   * Use this field if you want to identify an attribute with a specific type
+   */
+  attributesInfo?: {
+    /**
+     * Attribute name
+     */
+    name: string
+    /**
+     * Attribute type. Can be only `string`, `time`, `number`, `boolean`, `location`
+     */
+    type: string
+  }[]
+}

--- a/packages/destination-actions/src/destinations/talon-one/updateCustomerProfileV2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/talon-one/updateCustomerProfileV2/generated-types.ts
@@ -6,28 +6,28 @@ export interface Payload {
    */
   customerProfileId: string
   /**
-   * Audience name and integrationId
+   * Audience name and integration ID
    */
   audiencesToAdd?: {
     /**
-     * The name of the audience.
+     * The audience name.
      */
     name: string
     /**
-     * The integrationId of the audience.
+     * The audience integration ID.
      */
     integrationId?: string
   }[]
   /**
-   * Audience name and integrationId
+   * Audience name and integration ID
    */
   audiencesToDelete?: {
     /**
-     * The name of the audience.
+     * The audience name.
      */
     name: string
     /**
-     * The integrationId of the audience.
+     * The audience integration ID.
      */
     integrationId?: string
   }[]

--- a/packages/destination-actions/src/destinations/talon-one/updateCustomerProfileV2/index.ts
+++ b/packages/destination-actions/src/destinations/talon-one/updateCustomerProfileV2/index.ts
@@ -1,0 +1,72 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { attribute, audiencesToAdd, audiencesToDelete, customerProfileId } from '../t1-properties'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Update Customer Profile V2',
+  description: 'You do not have to create attributes or audiences before using this endpoint.',
+  fields: {
+    customerProfileId: { ...customerProfileId },
+    audiencesToAdd: { ...audiencesToAdd },
+    audiencesToDelete: { ...audiencesToDelete },
+    runRuleEngine: {
+      label: 'Run rule engine',
+      description: 'This runs rule engine in Talon.One upon updating customer profile. Set to true to trigger rules.',
+      type: 'boolean',
+      default: true
+    },
+    attributes: { ...attribute },
+    attributesInfo: {
+      label: 'Attributes info',
+      description: 'Use this field if you want to identify an attribute with a specific type',
+      type: 'object',
+      required: false,
+      multiple: true,
+      properties: {
+        name: {
+          label: 'Name',
+          description: 'Attribute name',
+          type: 'string',
+          required: true
+        },
+        type: {
+          label: 'Type',
+          description: 'Attribute type. Can be only `string`, `time`, `number`, `boolean`, `location`',
+          type: 'string',
+          required: true
+        }
+      },
+      default: {
+        '@arrayPath': [
+          '$.properties.attributesInfo',
+          {
+            name: {
+              '@path': '$.name'
+            },
+            type: {
+              '@path': '$.type'
+            }
+          }
+        ]
+      }
+    }
+  },
+  perform: (request, { payload }) => {
+    // Make your partner api request here!
+    return request(`https://integration.talon.one/segment/customer_profile_v2/${payload.customerProfileId}`, {
+      method: 'put',
+      json: {
+        audiencesChanges: {
+          adds: payload.audiencesToAdd,
+          deletes: payload.audiencesToDelete
+        },
+        runRuleEngine: payload.runRuleEngine,
+        attributes: payload.attributes,
+        attributesInfo: payload.attributesInfo
+      }
+    })
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/talon-one/updateCustomerSession/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/talon-one/updateCustomerSession/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for TalonOne's updateCustomerSession destination action: required fields 1`] = `
+Object {
+  "customerSession": Object {},
+}
+`;

--- a/packages/destination-actions/src/destinations/talon-one/updateCustomerSession/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/talon-one/updateCustomerSession/__tests__/index.test.ts
@@ -1,0 +1,115 @@
+import { createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(Destination)
+
+describe('TalonOne.updateCustomerSession', () => {
+  it('misses request body', async () => {
+    try {
+      await testDestination.testAction('updateCustomerSession', {
+        settings: {
+          apiKey: 'some_api_key',
+          deployment: 'https://internal.europe-west1.talon.one'
+        }
+      })
+    } catch (err) {
+      expect(err.message).toContain("The root value is missing the required field 'customerSessionId'.")
+    }
+  })
+
+  it('misses customerSession', async () => {
+    try {
+      await testDestination.testAction('updateCustomerSession', {
+        settings: {
+          apiKey: 'some_api_key',
+          deployment: 'https://internal.europe-west1.talon.one'
+        },
+        mapping: {
+          customerSessionId: 'session123abc'
+        }
+      })
+    } catch (err) {
+      expect(err.message).toContain("The root value is missing the required field 'customerSession'.")
+    }
+  })
+
+  it('misses customer session ID', async () => {
+    try {
+      await testDestination.testAction('updateCustomerSession', {
+        settings: {
+          apiKey: 'some_api_key',
+          deployment: 'https://something.europe-west1.talon.one'
+        },
+        mapping: {
+          customerSession: {},
+          sessionAttributesInfo: [],
+          cartItemAttributesInfo: []
+        }
+      })
+    } catch (err) {
+      expect(err.message).toContain("The root value is missing the required field 'customerSessionId'.")
+    }
+  })
+
+  it('should work', async () => {
+    nock('https://integration.talon.one')
+      .put(`/segment/customer_session/session123abc`, {
+        customerSession: {
+          state: 'open',
+          attributes: {
+            testAttribute1: 'value',
+            testAttribute2: 'value'
+          }
+        },
+        sessionAttributesInfo: [
+          {
+            name: 'testAttribute1',
+            type: 'string'
+          },
+          {
+            name: 'testAttribute2',
+            type: 'string'
+          }
+        ]
+      })
+      .matchHeader('Authorization', 'ApiKey-v1 some_api_key')
+      .matchHeader('destination-hostname', 'https://something.europe-west1.talon.one')
+      .matchHeader('X-Callback-Destination-URI', 'http://mydomain.com/api/callback_here')
+      .matchHeader('X-Callback-API-Key', 'X-API-Key 123456789123456789123456789123456789')
+      .matchHeader('X-Callback-Forwarded-Fields', 'effects')
+      .matchHeader('X-Correlation-ID', '123')
+      .reply(200)
+
+    await testDestination.testAction('updateCustomerSession', {
+      settings: {
+        apiKey: 'some_api_key',
+        deployment: 'https://something.europe-west1.talon.one'
+      },
+      mapping: {
+        customerSessionId: 'session123abc',
+        callbackDestination: 'http://mydomain.com/api/callback_here',
+        callbackAPIKey: 'X-API-Key 123456789123456789123456789123456789',
+        callbackForwardedFields: 'effects',
+        callbackCorrelationId: '123',
+        customerSession: {
+          state: 'open',
+          attributes: {
+            testAttribute1: 'value',
+            testAttribute2: 'value'
+          }
+        },
+        sessionAttributesInfo: [
+          {
+            name: 'testAttribute1',
+            type: 'string'
+          },
+          {
+            name: 'testAttribute2',
+            type: 'string'
+          }
+        ]
+      }
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/talon-one/updateCustomerSession/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/talon-one/updateCustomerSession/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'updateCustomerSession'
+const destinationSlug = 'TalonOne'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/talon-one/updateCustomerSession/generated-types.ts
+++ b/packages/destination-actions/src/destinations/talon-one/updateCustomerSession/generated-types.ts
@@ -1,0 +1,155 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The customer session integration identifier to use in Talon.One.
+   */
+  customerSessionId: string
+  /**
+   * This specifies the address of the service and its endpoint to do callback request.
+   */
+  callbackDestination?: string
+  /**
+   * This specifies API key and relative header. The header is specified optionally
+   */
+  callbackAPIKey?: string
+  /**
+   * This specifies a list of the fields from the response you need to receive. Comma character is separator. If omitted, all the fields will be forwarded from the response.
+   */
+  callbackForwardedFields?: string
+  /**
+   * This specifies ID of the request that will be forwarded to the destination URI with the callback request with the same header name. If omitted, the X-Correlation-ID will not be in the callback request.
+   */
+  callbackCorrelationId?: string
+  /**
+   * This contains all the data related to customer session.
+   */
+  customerSession: {
+    /**
+     * The customer profile integration identifier to use in Talon.One.
+     */
+    profileId?: string
+    /**
+     * Any coupon codes entered. Up to 100 coupons.`
+     */
+    couponCodes?: string[]
+    /**
+     * Any referral code entered.`
+     */
+    referralCode?: string
+    /**
+     * Any loyalty cards used. Up to 1 loyalty cards.`
+     */
+    loyaltyCards?: string[]
+    /**
+     * Indicates the current state of the session. `
+     */
+    state?: string
+    /**
+     * The items to add to this sessions.
+     *
+     * If cart item flattening is disabled: Do not exceed 1000 items (regardless of their quantity) per request.
+     * If cart item flattening is enabled: Do not exceed 1000 items and ensure the sum of all cart item's quantity does not exceed 10.000 per request.`
+     */
+    cardItems?: {
+      /**
+       * Name of item
+       */
+      name: string
+      /**
+       * Stock keeping unit of item.
+       */
+      sku: string
+      /**
+       * Quantity of item. Important: If you enabled cart item flattening, the quantity is always one and the same cart item might receive multiple per-item discounts. Ensure you can process multiple discounts on one cart item correctly.
+       */
+      quantity: number
+      /**
+       * Price of item.
+       */
+      price: number
+      /**
+       * Number of returned items, calculated internally based on returns of this item.
+       */
+      returnedQuantity?: string
+      /**
+       * Remaining quantity of the item, calculated internally based on returns of this item.
+       */
+      remainingQuantity?: string
+      /**
+       * Type, group or model of the item.
+       */
+      category?: string
+      /**
+       * Weight of item in grams.
+       */
+      weight?: string
+      /**
+       * Height of item in mm.
+       */
+      height?: string
+      /**
+       * Length of item in mm.
+       */
+      length?: string
+      /**
+       * Position of the Cart Item in the Cart (calculated internally).
+       */
+      position?: string
+      /**
+       * Use this property to set a value for the attributes of your choice. Attributes represent any information to attach to this cart item.
+       *
+       * Custom cart item attributes must be created in the Campaign Manager before you set them with this property.
+       *
+       * [See more info](https://docs.talon.one/docs/product/account/dev-tools/managing-attributes).
+       */
+      attributes?: {
+        [k: string]: unknown
+      }
+      /**
+       * Use this property to set a value for the additional costs of this session, such as a shipping cost.`
+       */
+      additionalCosts?: {
+        [k: string]: unknown
+      }
+    }[]
+    /**
+     * Use this property to set a value for the additional costs of this session, such as a shipping cost.`
+     */
+    additionalCosts?: {
+      [k: string]: unknown
+    }
+    /**
+     * Use this property to set a value for the attributes of your choice. Attributes represent any information to attach to your session, like the shipping city. [See more info](https://docs.talon.one/docs/product/account/dev-tools/managing-attributes).
+     */
+    attributes?: {
+      [k: string]: unknown
+    }
+  }
+  /**
+   * Use this field if you want to identify an attribute with a specific type
+   */
+  sessionAttributesInfo?: {
+    /**
+     * Attribute name
+     */
+    name: string
+    /**
+     * Attribute type. Can be only `string`, `time`, `number`, `boolean`, `location`
+     */
+    type: string
+  }[]
+  /**
+   * Use this field if you want to identify an attribute with a specific type
+   */
+  cartItemsAttributesInfo?: {
+    /**
+     * Attribute name
+     */
+    name: string
+    /**
+     * Attribute type. Can be only `string`, `time`, `number`, `boolean`, `location`
+     */
+    type: string
+  }[]
+}

--- a/packages/destination-actions/src/destinations/talon-one/updateCustomerSession/index.ts
+++ b/packages/destination-actions/src/destinations/talon-one/updateCustomerSession/index.ts
@@ -1,0 +1,205 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { attribute, attributesInfo, customerProfileId } from '../t1-properties'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Update Customer Sessions',
+  description: 'This updates a customer session.',
+  fields: {
+    customerSessionId: {
+      label: 'Customer Session ID',
+      description: 'The customer session integration identifier to use in Talon.One.',
+      type: 'string',
+      required: true
+    },
+    callbackDestination: {
+      label: 'Callback Destination URI',
+      description: 'This specifies the address of the service and its endpoint to do callback request.',
+      type: 'string',
+      placeholder: 'http://mydomain.com/api/callback_here'
+    },
+    callbackAPIKey: {
+      type: 'string',
+      label: 'Callback API Key',
+      description: 'This specifies API key and relative header. The header is specified optionally',
+      placeholder: 'X-API-Key 123456789123456789123456789123456789'
+    },
+    callbackForwardedFields: {
+      type: 'string',
+      label: 'Callback Forwarded Fields',
+      description:
+        'This specifies a list of the fields from the response you need to receive. Comma character is separator. If omitted, all the fields will be forwarded from the response.',
+      placeholder: 'effects,customerProfile',
+      default: 'effects'
+    },
+    callbackCorrelationId: {
+      type: 'string',
+      label: 'Correlation ID',
+      description:
+        'This specifies ID of the request that will be forwarded to the destination URI with the callback request with the same header name. If omitted, the X-Correlation-ID will not be in the callback request.'
+    },
+    customerSession: {
+      label: 'Customer Profile ID',
+      description: 'This contains all the data related to customer session.',
+      type: 'object',
+      required: true,
+      properties: {
+        profileId: { ...customerProfileId, required: false },
+        couponCodes: {
+          label: 'Coupon Codes',
+          description: 'Any coupon codes entered. Up to 100 coupons.`',
+          type: 'string',
+          multiple: true
+        },
+        referralCode: {
+          label: 'Referral Codes',
+          description: 'Any referral code entered.`',
+          type: 'string'
+        },
+        loyaltyCards: {
+          label: 'Referral Codes',
+          description: 'Any loyalty cards used. Up to 1 loyalty cards.`',
+          type: 'string',
+          multiple: true
+        },
+        state: {
+          label: 'State',
+          description: 'Indicates the current state of the session. `',
+          type: 'string',
+          choices: [
+            { label: 'Open', value: 'open' },
+            { label: 'Closed', value: 'closed' },
+            { label: 'Partially returned', value: 'partially_returned' },
+            { label: 'Cancelled', value: 'cancelled' }
+          ]
+        },
+        cardItems: {
+          label: 'Card Items',
+          description:
+            'The items to add to this sessions.\n' +
+            '\n' +
+            'If cart item flattening is disabled: Do not exceed 1000 items (regardless of their quantity) per request.\n' +
+            "If cart item flattening is enabled: Do not exceed 1000 items and ensure the sum of all cart item's quantity does not exceed 10.000 per request.`",
+          type: 'object',
+          multiple: true,
+          required: false,
+          properties: {
+            name: {
+              label: 'Name',
+              description: 'Name of item',
+              type: 'string',
+              required: true
+            },
+            sku: {
+              label: 'SKU',
+              description: 'Stock keeping unit of item.',
+              type: 'string',
+              required: true
+            },
+            quantity: {
+              label: 'Quantity',
+              description:
+                'Quantity of item. Important: If you enabled cart item flattening, the quantity is always one and the same cart item might receive multiple per-item discounts. Ensure you can process multiple discounts on one cart item correctly.',
+              type: 'number',
+              required: true
+            },
+            price: {
+              label: 'Price',
+              description: 'Price of item.',
+              type: 'number',
+              required: true
+            },
+            returnedQuantity: {
+              label: 'Returned quantity',
+              description: 'Number of returned items, calculated internally based on returns of this item.',
+              type: 'string'
+            },
+            remainingQuantity: {
+              label: 'Remaining quantity',
+              description: 'Remaining quantity of the item, calculated internally based on returns of this item.',
+              type: 'string'
+            },
+            category: {
+              label: 'Category',
+              description: 'Type, group or model of the item.',
+              type: 'string'
+            },
+            weight: {
+              label: 'Weight',
+              description: 'Weight of item in grams.',
+              type: 'string'
+            },
+            height: {
+              label: 'Height',
+              description: 'Height of item in mm.',
+              type: 'string'
+            },
+            length: {
+              label: 'Length',
+              description: 'Length of item in mm.',
+              type: 'string'
+            },
+            position: {
+              label: 'Position',
+              description: 'Position of the Cart Item in the Cart (calculated internally).',
+              type: 'string'
+            },
+            attributes: {
+              ...attribute,
+              default: {
+                '@path': '$.properties.attributes'
+              },
+              description:
+                'Use this property to set a value for the attributes of your choice. Attributes represent any information to attach to this cart item.\n' +
+                '\n' +
+                'Custom cart item attributes must be created in the Campaign Manager before you set them with this property.\n' +
+                '\n' +
+                '[See more info](https://docs.talon.one/docs/product/account/dev-tools/managing-attributes).'
+            },
+            additionalCosts: {
+              label: 'Additional Costs',
+              description:
+                'Use this property to set a value for the additional costs of this session, such as a shipping cost.`',
+              type: 'object'
+            }
+          }
+        },
+        additionalCosts: {
+          label: 'Additional Costs',
+          description:
+            'Use this property to set a value for the additional costs of this session, such as a shipping cost.`',
+          type: 'object'
+        },
+        attributes: {
+          ...attribute,
+          default: {
+            '@path': '$.properties.attributes'
+          },
+          description:
+            'Use this property to set a value for the attributes of your choice. Attributes represent any information to attach to your session, like the shipping city. [See more info](https://docs.talon.one/docs/product/account/dev-tools/managing-attributes).'
+        }
+      }
+    },
+    sessionAttributesInfo: { ...attributesInfo },
+    cartItemsAttributesInfo: { ...attributesInfo }
+  },
+  perform: (request, { payload }) => {
+    return request(`https://integration.talon.one/segment/customer_sessions/${payload.customerSessionId}`, {
+      method: 'put',
+      headers: {
+        'X-Callback-Destination-URI': `${payload.callbackDestination}`,
+        'X-Callback-API-Key': `${payload.callbackAPIKey}`,
+        'X-Callback-Forwarded-Fields': `${payload.callbackForwardedFields}`,
+        'X-Correlation-ID': `${payload.callbackCorrelationId}`
+      },
+      json: {
+        customerSession: payload.customerSession,
+        sessionAttributesInfo: payload.sessionAttributesInfo,
+        cartItemAttributesInfo: payload.cartItemsAttributesInfo
+      }
+    })
+  }
+}
+
+export default action


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

- A new action `updateCustomerProfileV2` was added. It allows the customers to add a user to an audience without creating the audience before.
- A new action `updateCustomerSessions` was added. It allows the customers to update customer sessions.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
